### PR TITLE
Fix git error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 cd "$GITHUB_WORKSPACE" || exit
 
+git config --global --add safe.directory $GITHUB_WORKSPACE
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 yamllint --version


### PR DESCRIPTION
The GitHub Actions fails Due to Git v2.35.2 spec changes.
https://github.com/reviewdog/reviewdog/issues/1158#issue-1202862728
https://github.com/reviewdog/action-yamllint/issues/18

This PR will solve the problem.