### PR TITLE
Fix yamllint installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV REVIEWDOG_VERSION=v0.14.2
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 RUN apk --no-cache add git
 
-RUN pip install yamllint
+RUN pip install "pyyaml<=5.3.1" "yamllint"
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
yamllint check started to fail on Jul 17, 2023. It’s failing at the stage of installation.
pyyaml v5.4 causes the issue. See more: https://github.com/yaml/pyyaml/issues/601

That's a temporary fix that tags an older version of the pyyaml.

Fixes https://github.com/reviewdog/action-yamllint/issues/27