### PR TITLE
Add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,15 @@ github-pr-review can use Markdown and add a link to rule page in reviewdog repor
 
 Optional. Filtering mode for the reviewdog command [added,diff_context,file,nofilter]. Default is added.
 
+### `fail_level`
+
+Optional. If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Possible values: [`none`, `any`, `info`, `warning`, `error`]
+Default is `none`.
+
 ### `fail_on_error`
 
+Deprecated, use `fail_level` instead.
 Optional. Exit code for reviewdog when errors are found [true,false] Default is `false`.
 
 ### `reviewdog_flags`

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,18 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: "added"
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: "false"
   reviewdog_flags:
     description: "Additional reviewdog flags"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ yamllint --format "parsable" ${INPUT_YAMLLINT_FLAGS:-'.'} |
         -reporter="${INPUT_REPORTER:-github-pr-check}" \
         -level="${INPUT_LEVEL}" \
         -filter-mode="${INPUT_FILTER_MODE}" \
+        -fail-level="${INPUT_FAIL_LEVEL}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
         ${INPUT_REVIEWDOG_FLAGS}
 EXIT_CODE=$?


### PR DESCRIPTION
In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply this to `action-shellcheck`.